### PR TITLE
feat: add check for allowing all entities in lasso

### DIFF
--- a/src/main/java/com/empressvalla/emeraldlasso/config/ConfigManager.java
+++ b/src/main/java/com/empressvalla/emeraldlasso/config/ConfigManager.java
@@ -36,6 +36,12 @@ public class ConfigManager {
     private static final ForgeConfigSpec.ConfigValue<Boolean> HAS_DURABILITY;
 
     /**
+     * Responsible for storing the config value which controls whether
+     * the lasso can store all entities.
+     */
+    private static final ForgeConfigSpec.ConfigValue<Boolean> ALLOW_ALL_ENTITIES;
+
+    /**
      * Responsible for storing the config value which controls which entities can be picked
      * up by the lasso.
      */
@@ -78,6 +84,9 @@ public class ConfigManager {
 
         HAS_DURABILITY = BUILDER.comment("Should the lasso have a durability? Set to false if you'd like it to take no damage")
                                 .define("has_durability", true);
+
+        ALLOW_ALL_ENTITIES = BUILDER.comment("Do you want the lasso to pick up all entity types? Note this will bypass whatever is in the whitelists")
+                                    .define("allow_all_entities", false);
 
         //The validator checks that the input is a string and that it follows the expected resource pattern. I.E minecraft:pig
         Predicate<Object> entityWhitelistValidator =  s -> s instanceof String && ((String) s).matches("[a-z0-9]+:[a-z_]+");
@@ -159,6 +168,19 @@ public class ConfigManager {
      */
     public static boolean hasDurability() {
         return HAS_DURABILITY.get();
+    }
+
+    /**
+     * This method is responsible for returning the boolean
+     * which was provided in the ALLOW_ALL_ENTITIES
+     * config value.
+     *
+     * @see ConfigManager#ALLOW_ALL_ENTITIES
+     *
+     * @return The boolean value retrieved from ALLOW_ALL_ENTITIES.
+     */
+    public static boolean allEntitiesAllowed() {
+        return ALLOW_ALL_ENTITIES.get();
     }
 
 }

--- a/src/main/java/com/empressvalla/emeraldlasso/item/advanced/EmeraldLassoItem.java
+++ b/src/main/java/com/empressvalla/emeraldlasso/item/advanced/EmeraldLassoItem.java
@@ -193,11 +193,17 @@ public class EmeraldLassoItem extends Item {
      * @return {@code true} if the entity is valid {@code false} otherwise.
      */
     private boolean isEntityValid(Entity target) {
-        if(entityWhitelist.isEmpty()) {
-            entityWhitelist = ConfigManager.getEntityWhiteList();
+        boolean baseCheck = target instanceof LivingEntity && target.isAlive() && !target.isInWall();
+
+        if(ConfigManager.allEntitiesAllowed()) {
+            return baseCheck;
         }
 
         boolean whitelistCheck = false;
+
+        if(entityWhitelist.isEmpty()) {
+            entityWhitelist = ConfigManager.getEntityWhiteList();
+        }
 
         for(EntityType<?> type : entityWhitelist) {
             if(target.getType().equals(type)) {
@@ -207,7 +213,7 @@ public class EmeraldLassoItem extends Item {
             }
         }
 
-        return target instanceof LivingEntity && target.isAlive() && !target.isInWall() && whitelistCheck;
+        return baseCheck && whitelistCheck;
     }
 
     /**

--- a/src/main/java/com/empressvalla/emeraldlasso/item/advanced/EmeraldLassoItem.java
+++ b/src/main/java/com/empressvalla/emeraldlasso/item/advanced/EmeraldLassoItem.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -39,12 +40,20 @@ import java.util.List;
  */
 public class EmeraldLassoItem extends Item {
 
+    /**
+     * This list holds the whitelist of entity types which are allowed in the lasso.
+     * This will start off empty but be populated from the config file the first
+     * time an entity is interacted with.
+     *
+     * @see ConfigManager#getEntityWhiteList() For more details.
+     */
+    private static List<EntityType<?>> entityWhitelist = new ArrayList<>();
+
     public EmeraldLassoItem(Properties properties) {
         super(properties.tab(ModCreativeModeTab.EMERALD_LASSO_TAB)
                 .stacksTo(1)
                 .durability(250));
     }
-
 
     @Override
     public boolean doesSneakBypassUse(ItemStack stack, LevelReader level, BlockPos pos, Player player) {
@@ -184,7 +193,9 @@ public class EmeraldLassoItem extends Item {
      * @return {@code true} if the entity is valid {@code false} otherwise.
      */
     private boolean isEntityValid(Entity target) {
-        List<EntityType<?>> entityWhitelist = ConfigManager.getEntityWhiteList();
+        if(entityWhitelist.isEmpty()) {
+            entityWhitelist = ConfigManager.getEntityWhiteList();
+        }
 
         boolean whitelistCheck = false;
 


### PR DESCRIPTION
Adds functionality described in issue #4. The lasso can now be toggled to instead pick up all entities and bypass the whitelist. This also incorporates an optimization fix where the entity whitelist was being called more times than necessary.

Closes #4. 