### PR TITLE
feat: add player prompt for entity health system

### DIFF
--- a/src/main/java/com/empressvalla/emeraldlasso/item/advanced/EmeraldLassoItem.java
+++ b/src/main/java/com/empressvalla/emeraldlasso/item/advanced/EmeraldLassoItem.java
@@ -101,6 +101,8 @@ public class EmeraldLassoItem extends Item {
                                   && isEntityValid(targetEntity)
                                   && entityList.size() != ConfigManager.getNumAllowedEntities();
 
+        Level level = player.getLevel();
+
         if(ConfigManager.entityHealthSystemEnabled()) {
             // Reminder: We already checked if the target is of type LivingEntity in isEntityValid, so we can safely cast it.
             LivingEntity livingEntityTarget = (LivingEntity) targetEntity;
@@ -110,10 +112,15 @@ public class EmeraldLassoItem extends Item {
             double minEntityHealth = ConfigManager.getMinEntityHealth();
 
             requirementsMet = requirementsMet && health <= minEntityHealth;
+
+            if(health > minEntityHealth && !level.isClientSide()){
+                player.sendSystemMessage(
+                         MutableComponent.create(new TranslatableContents("emeraldlasso.messages.entity_health_high", health, minEntityHealth))
+                                         .setStyle(Style.EMPTY.applyFormat(ChatFormatting.RED)));
+            }
         }
 
         if(requirementsMet) {
-            Level level = player.getLevel();
 
             if(!level.isClientSide()) {
                 targetEntity.stopRiding();

--- a/src/main/resources/assets/emeraldlasso/lang/en_us.json
+++ b/src/main/resources/assets/emeraldlasso/lang/en_us.json
@@ -7,5 +7,7 @@
 
   "emeraldlasso.tooltips.release": "Right click on a block to release a stored entity",
 
-  "emeraldlasso.tooltips.entities": "Entity: %s"
+  "emeraldlasso.tooltips.entities": "Entity: %s",
+
+  "emeraldlasso.messages.entity_health_high": "The entity's health %s is too high to be stored, please lower to %s or less"
 }


### PR DESCRIPTION
Address issue #2 by adding a player prompt to the entity health system. Decided that it's only really worth it to prompt the player for this system, rather than every action.

Closes #2 