### PR TITLE
chore(forge): update forge and parchment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,33 @@ who play. Now of course, there are probably much more polished mods out there th
 cooler than what I have made! :)
 
 ## Current Features/Config Options
-At the moment I've kept the item very much to what I had in mind for playing. I wanted it to be able to pick up and retrieve entites, and I wanted to be able to
-pick and choose what I could pick up, depending on what I'm playing. You'll find a common config file when you add this mod that contains the following options:
+
+### For Latest Version 1.1.0
+
+By default the lasso can pick up all entities, you can change this in the config. For more details see below.
+
+Note: AS ALWAYS WITH MINECRAFT MODS PLEASE BACK UP YOUR WORLD BEFORE UPDATING THIS. IT IS SO EASY TO BREAK THINGS SO IF YOU HAVE A WORLD THAT YOU HAVE PLAYED FOR A LONG TIME I WOULD SUGGEST HOLDING OFF FOR NOW.
+
+Also if you're wondering where [insert new minecraft game version here] is. I am probably in the process of updating, so just wait a little while.
+
+You'll find a common config file when you add this mod that contains the following options:
 
 1. num_entities_allowed - Lets you control how many entities the lasso can store. You can toggle this to between 1 and 5. 1 is the default
-2. has_durability - Lets you control whether the lasso should have a durability or not. This is set to true by default.
-3. vanilla_entity_whitelist - Lets you control what entities the lasso is able to pick up. Note this must have at least one value. By default most of the animals
-and regular villagers are allowed. To add to this, you should follow the pattern of using the resource location. Which is usually id:name. For example if you want to
-add the wandering trader, you would add "minecraft:wandering_trader" to the list. 
-4. mod_entity_whitelist - The same as above, but for entities added by mods. You can actually put these in either but I made this so that you can keep them separate. You should follow
-the same pattern as above. If you're unsure about a mods id. The quickest way to find it is to use the /give command in game. If you search for an item in the mod, it
-will display what the id is. I.E /give EmpressValla itemname
+2. has_durability - Lets you control whether the lasso should have a durability or not. This is set to true by default. Durability is 250.
+3. allow_all_entities - This config option is used to determine whether you want to use the entity whitelist or just let all entities (not including boss entities of course) be stored in the lasso. I.E ignore the whitelist. This is set to true by default, if you want to use the whitelist set this to false.
+4. entity_health_system - Lets you decide whether an entity must be dropped to a certain health before being able to be stored or not. This is set to false by default, so if you want to use this system set it to true.
+5. min_entity_health - Used for the above entity health system. This is the minimum health you must lower an entity to before it can be stored. You must set 6. entity_health_system to true or this will be completely ignored. Range is between 1.5 and 500.
+7. vanilla_entity_whitelist - Lets you control what entities the lasso is able to pick up. Note this must have at least one value. There are some added by default to guide you with how to add entities. To add to this, you should follow the pattern of using the resource location. Which is usually id:name. For example if you want to add the wandering trader, you would add "minecraft:wandering_trader" to the list. Note that you must set allow_all_entities to false or else both whitelists will be completely ignored.
+8. mod_entity_whitelist - The same as above, but for entities added by mods. You can actually put these in either but I made this so that you can keep them separate. You should follow the same pattern as above. If you're unsure about a mods id. The quickest way to find it is to use the /give command in game. If you search for an item in the mod, it will display what the id is. I.E /give EmpressValla itemname.
+
+### For Version 1.0.3 and Below
+
+You'll find a common config file when you add this mod that contains the following options:
+
+1. num_entities_allowed - Lets you control how many entities the lasso can store. You can toggle this to between 1 and 5. 1 is the default
+2. has_durability - Lets you control whether the lasso should have a durability or not. This is set to true by default. Durability is 250.
+3. vanilla_entity_whitelist - Lets you control what entities the lasso is able to pick up. Note this must have at least one value. By default most of the animals and regular villagers are allowed. To add to this, you should follow the pattern of using the resource location. Which is usually id:name. For example if you want to add the wandering trader, you would add "minecraft:wandering_trader" to the list.
+4. mod_entity_whitelist - The same as above, but for entities added by mods. You can actually put these in either but I made this so that you can keep them separate. You should follow the same pattern as above. If you're unsure about a mods id. The quickest way to find it is to use the /give command in game. If you search for an item in the mod, it will display what the id is. I.E /give EmpressValla itemname
 
 ## Offering Help/Suggestions & Reporting Issues
 I am always open to help or suggestions. Although I am not new to writing in Java, I am new to making mods so there are likely some mistakes or potential bugs
@@ -28,10 +44,8 @@ that I have not caught. If possible, please use the issue tab here for reporting
 than comments. Please try and be as detailed as possible, if it's an issue with picking up an entity let me know what mod it is from and what the entity is. If it's a crash
 let me know the conditions that caused the crash. That way it's much easier for me to try and reproduce it in testing. You can use the issue tab for suggesting
 new features as well, just tag them with something like feature so I can filter them.
-<br>
-<br>
-**Additionally, as you can probably tell by the texture for this mod I am an awful pixel artist. So if anyone wants to make something prettier and nicer feel free
-to contact me on my discord (shown in the social section) and if I accept it I'll add credit here**
+
+**BronyPie is a good friend of mine and made a more lasso like texture for the mod so his paypal is linked below in the socials as well if you'd like to help out.**
 
 ## Pull Requests/Contributing
 I am totally fine with people submitting a pull request on here for an improvement or otherwise. Just like for offering help if you are going to submit a PR
@@ -41,10 +55,9 @@ readily about. Of course give me time to look through things. I'm not a wizard..
 ## Socials
 - Discord: EmpressValla#2365
 - Email: hyperconix@pm.me
-- Paypal: https://www.paypal.com/paypalme/IWuvStarlight
+- Paypal: [My Paypal](https://www.paypal.com/paypalme/IWuvStarlight)
+- BronyPie's Paypal: [Here](https://www.paypal.com/paypalme/BronyPie)
 
 ## License
 I will be keeping this repo and source code MIT. So you're free to use it however you wish. At the moment I'm still using a texture which I made myself so you're free
 to use that as well. If that changes, you may need to add an additional license for the texture but I will update the readme if that is the case.
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 
 
-version = '1.1.0-1.19.2'
+version = '1.1.0-1.19.3'
 group = 'com.empressvalla.emeraldlasso' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'emeraldlasso'
 
@@ -41,7 +41,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'parchment', version: '2022.10.16-1.19.2'
+    mappings channel: 'parchment', version: '2022.12.18-1.19.3'
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
@@ -154,7 +154,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19.2-43.1.47'
+    minecraft 'net.minecraftforge:forge:1.19.3-44.0.37'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency


### PR DESCRIPTION
Forge and parchment updated to their relevant versions for 1.19.3.

I forgot about updating the readme before beginning this work, so that has been addressed in this PR.

Closes #13 